### PR TITLE
fix: smallvec-responses no_std compat + conditional serde (#17)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ curve25519-dalek = { version = "4", default-features = false }
 digest = { version = "^0.10", default-features = false }
 rand_core = { version = "^0.6.4", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-smallvec = { version = "1", optional = true, default-features = false, features = ["const_generics", "write", "serde"] }
+smallvec = { version = "1", optional = true, default-features = false }
 wasm-bindgen = { version = "0.2.104", optional = true }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 rand = { version = "^0.8", default-features = false, features = ["getrandom"], optional = true }
@@ -41,7 +41,7 @@ rand_chacha = "0.3"
 [features]
 default = ["std", "serde-derive", "optimized-msm", "cpu-time"]
 optimized-msm = ["curve25519-dalek/alloc"]
-serde-derive = ["serde", "curve25519-dalek/serde", "no_std"]
+serde-derive = ["serde", "curve25519-dalek/serde", "no_std", "smallvec?/serde"]
 std = [
     "digest/std",
     "rand_core/std",


### PR DESCRIPTION
## Summary

Fixes P1 and P2 from #17. M1 (docs verify signature) determined to be false positive via codex debate — see [issue comment](https://github.com/RyderFreeman4Logos/nazgul/issues/17#issuecomment-4065806449).

- **P1**: Removed `write` feature from `smallvec` dep — it pulls in `std::io::Write` which breaks `#![no_std]` targets
- **P2**: Removed unconditional `serde` from `smallvec` dep, added `smallvec?/serde` to `serde-derive` feature (Cargo 1.60+ weak dep syntax) — serde is now only enabled when both `serde-derive` and `smallvec-responses` are active
- Also removed `const_generics` — not needed for `SmallVec<[Scalar; 16]>` (N=16 in smallvec built-in macro)

## Verification

| Check | Result |
|-------|--------|
| `cargo check --no-default-features --features no_std,smallvec-responses` | ✅ |
| `cargo check --no-default-features --features serde-derive,smallvec-responses` | ✅ |
| `cargo check --features smallvec-responses` | ✅ |
| `cargo check` (default features) | ✅ |
| `just pre-commit` | ✅ |

## Test plan

- [x] P1: `no_std + smallvec-responses` compiles without linking std
- [x] P2: `smallvec-responses` alone does not pull in serde
- [x] P2: `serde-derive + smallvec-responses` enables smallvec/serde
- [x] Default features unaffected
- [x] Full pre-commit suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)