### PR TITLE
fix: constant-time identity comparison + unused import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ digest = { version = "^0.10", default-features = false }
 rand_core = { version = "^0.6.4", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = { version = "1", optional = true, default-features = false }
+subtle = { version = "2", default-features = false }
 wasm-bindgen = { version = "0.2.104", optional = true }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 rand = { version = "^0.8", default-features = false, features = ["getrandom"], optional = true }

--- a/src/blsag/mod.rs
+++ b/src/blsag/mod.rs
@@ -70,6 +70,7 @@ pub use streaming::{
     StepOutput, StreamingBlsagSigner, StreamingBlsagVerifier, StreamingError, VerifyStepOutput,
 };
 
+#[cfg(not(feature = "smallvec-responses"))]
 use crate::prelude::*;
 use crate::ring::Ring;
 use crate::traits::LinkRef;

--- a/src/blsag/streaming.rs
+++ b/src/blsag/streaming.rs
@@ -27,6 +27,7 @@ use digest::generic_array::typenum::U64;
 use digest::Digest;
 use rand_core::{CryptoRng, RngCore};
 use sha3::Sha3_512;
+use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
 /// Errors specific to the streaming signing protocol.
@@ -304,7 +305,7 @@ impl<H: Digest<OutputSize = U64> + Clone + Default, R: CryptoRng + RngCore>
         // Verify the secret key corresponds to the claimed signer public key.
         // This mirrors the SignerNotFound check in the one-shot BLSAG::sign.
         let derived_pubkey = (secret_key * constants::RISTRETTO_BASEPOINT_POINT).compress();
-        if derived_pubkey != *signer_pubkey_compressed {
+        if derived_pubkey.as_bytes().ct_eq(signer_pubkey_compressed.as_bytes()).unwrap_u8() == 0 {
             return Err(StreamingError::IdentityMismatch);
         }
 
@@ -409,7 +410,12 @@ impl<H: Digest<OutputSize = U64> + Clone + Default, R: CryptoRng + RngCore>
             // This closes the gap between init_signing (which verified sk*G == claimed pk)
             // and the actual ring: the member delivered here during Phase 2 MUST equal
             // the pubkey we derived from the secret key.
-            if *compressed != signing.derived_signer_compressed {
+            if compressed
+                .as_bytes()
+                .ct_eq(signing.derived_signer_compressed.as_bytes())
+                .unwrap_u8()
+                == 0
+            {
                 self.state = State::Poisoned;
                 return Err(StreamingError::IdentityMismatch);
             }


### PR DESCRIPTION
## Summary

- **#35**: Use `subtle::ConstantTimeEq` for `CompressedRistretto` identity checks in `init_signing` and `sign_member` — defense-in-depth crypto hygiene
- **#36**: Gate `prelude::*` import on `not(smallvec-responses)` — fixes unused-import error under `--all-features` (`Vec` only needed when `SmallVec` is off)
- **#34**: Closed as documented known limitation (PR #28 threat model T5, PR #33 debate verdict)

## Test plan

- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo clippy -- -D warnings` clean (default features)
- [x] 135 tests pass (88 unit + 20 integration + 3 contextual + 4 no_std + 8 serde + 3 streaming + 9 doc)

Closes #35, closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)